### PR TITLE
Force local socks5 server to listen on localhost to avoid unintended security issue

### DIFF
--- a/dragonite-proxy/src/main/java/com/vecsight/dragonite/proxy/network/client/ProxyClient.java
+++ b/dragonite-proxy/src/main/java/com/vecsight/dragonite/proxy/network/client/ProxyClient.java
@@ -78,7 +78,7 @@ public class ProxyClient {
             Logger.info("ACL loaded: {} by {}", acl.getTitle(), acl.getAuthor());
         }
 
-        serverSocket = new ServerSocket(socks5port);
+        serverSocket = new ServerSocket(socks5port,2048,InetAddress.getByName("localhost"));
 
         prepareUnderlyingConnection(dragoniteSocketParameters);
 


### PR DESCRIPTION
Currently, dragonite-proxy will listen for socks5 connections on all interfaces, which can introduce unexpected security and abuse risks.

It would be avoided by restricting listen address to localhost.

In the long run, a configure option should be introduced to define socks5 listening address.